### PR TITLE
Default to `localhost` for the server `host` config

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5150,9 +5150,6 @@
         "mocha-remote-cli": "^1.6.1",
         "mocha-remote-client": "^1.6.1",
         "mocha-remote-server": "^1.6.0"
-      },
-      "bin": {
-        "mocha-remote": "cli.js"
       }
     },
     "packages/common": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -5168,8 +5168,8 @@
       "name": "mocha-remote-integration-tests",
       "version": "1.6.1",
       "dependencies": {
-        "mocha-remote-client": "^1.6.1",
-        "mocha-remote-server": "^1.6.0"
+        "mocha-remote-client": "*",
+        "mocha-remote-server": "*"
       }
     },
     "packages/mocha": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -5,7 +5,6 @@
   "main": "dist/index.js",
   "scripts": {
     "build": "tsc -p tsconfig.build.json",
-    "prepare": "npm run build",
     "prepack": "cp ../../README.md .",
     "test": "mocha",
     "start": "ts-node src/index.ts"

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -4,7 +4,6 @@
   "description": "Run Mocha tests somewhere - get reporting elsewhere",
   "scripts": {
     "build": "tsc --project tsconfig.build.json --emitDeclarationOnly && rollup -c",
-    "prepare": "npm run build",
     "prepack": "cp ../../README.md .",
     "test": "mocha"
   },

--- a/packages/combined/package.json
+++ b/packages/combined/package.json
@@ -6,7 +6,6 @@
   "types": "index.d.ts",
   "scripts": {
     "build": "echo 'Nothing to build in the combined package'",
-    "prepare": "npm run build",
     "prepack": "cp ../../README.md .",
     "test": "echo 'No tests to run'"
   },

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -4,7 +4,6 @@
   "description": "All common code and types shared between the Mocha Remote server and client",
   "scripts": {
     "build": "tsc -p tsconfig.build.json",
-    "prepare": "npm run build",
     "prepack": "cp ../../README.md .",
     "test": "mocha **/*.test.ts"
   },

--- a/packages/integration-tests/package.json
+++ b/packages/integration-tests/package.json
@@ -7,6 +7,15 @@
     "build": "echo 'No need to build the tests'",
     "test": "mocha **/*.test.ts"
   },
+  "nx": {
+    "targets": {
+      "test": {
+        "dependsOn": [
+          "^build"
+        ]
+      }
+    }
+  },
   "files": [
     "src"
   ],
@@ -16,8 +25,8 @@
     "url": "https://github.com/kraenhansen"
   },
   "dependencies": {
-    "mocha-remote-client": "^1.6.1",
-    "mocha-remote-server": "^1.6.0"
+    "mocha-remote-client": "*",
+    "mocha-remote-server": "*"
   },
   "mocha": {
     "extension": [

--- a/packages/integration-tests/src/basic.test.ts
+++ b/packages/integration-tests/src/basic.test.ts
@@ -1,10 +1,7 @@
 import { expect } from "chai";
-import Mocha from "mocha";
 
 import { Client } from "mocha-remote-client";
 import { Server } from "mocha-remote-server";
-
-import { MockedMocha } from "./utils";
 
 describe("basic", () => {
   let server: Server;
@@ -23,7 +20,10 @@ describe("basic", () => {
     // Create a server - which is supposed to run in Node
     server = new Server();
     await server.start();
-    expect(server.url).to.equal("ws://0.0.0.0:8090");
+    expect(server.url).to.oneOf([
+      "ws://localhost:8090",
+      "ws://[::1]:8090"
+    ]);
   });
 
   it("connects", async () => {

--- a/packages/mocha/package.json
+++ b/packages/mocha/package.json
@@ -5,7 +5,6 @@
   "description": "An internal simplified version of Mocha to be used from a client",
   "scripts": {
     "build": "webpack",
-    "prepare": "npm run build",
     "test": "echo 'No tests to run'"
   },
   "main": "dist/mocha.node.bundle.js",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -4,7 +4,6 @@
   "description": "Run Mocha tests somewhere - get reporting elsewhere",
   "scripts": {
     "build": "tsc -p tsconfig.build.json",
-    "prepare": "npm run build",
     "prepack": "cp ../../README.md .",
     "test": "mocha **/*.test.ts"
   },

--- a/packages/server/src/Server.ts
+++ b/packages/server/src/Server.ts
@@ -71,7 +71,7 @@ export interface ServerConfig {
 export class Server extends ServerEventEmitter {
   public static DEFAULT_CONFIG: ServerConfig = {
     autoStart: false,
-    host: "0.0.0.0",
+    host: "localhost",
     id: "default",
     port: 8090,
     autoRun: false,
@@ -272,8 +272,12 @@ export class Server extends ServerEventEmitter {
 
   public get url(): string {
     if (this.wss) {
-      const { address, port } = this.wss.address() as WebSocket.AddressInfo;
-      return `ws://${address}:${port}`;
+      const { address, port, family } = this.wss.address() as WebSocket.AddressInfo;
+      if (family === "IPv6") {
+        return `ws://[${address}]:${port}`;
+      } else {
+        return `ws://${address}:${port}`;
+      }
     } else {
       throw new Error("Cannot get url of a server that is not listening");
     }
@@ -339,7 +343,7 @@ export class Server extends ServerEventEmitter {
       if (typeof msg.action !== "string") {
         throw new Error("Expected message to have an action property");
       }
-      
+
       this.debug(`Received a '${msg.action}' message: %o`, msg);
       if (msg.action === "event") {
         if (this.runner) {


### PR DESCRIPTION
## Breaking 💥 

This PR updates the default hostname to point to `localhost` instead of the `0.0.0.0` loop back IPv4 address, which might break some situations.

The tests depends on defaults for the server and client to connect to listen on an connect to same host.
As the `Server` had a default on an IPv4 address (`0.0.0.0`) the tests failed on a machine with IPv6 enabled by default.