### PR TITLE
Default to `localhost` for the server `host` config

### DIFF
--- a/packages/integration-tests/src/basic.test.ts
+++ b/packages/integration-tests/src/basic.test.ts
@@ -1,10 +1,7 @@
 import { expect } from "chai";
-import Mocha from "mocha";
 
 import { Client } from "mocha-remote-client";
 import { Server } from "mocha-remote-server";
-
-import { MockedMocha } from "./utils";
 
 describe("basic", () => {
   let server: Server;
@@ -23,7 +20,10 @@ describe("basic", () => {
     // Create a server - which is supposed to run in Node
     server = new Server();
     await server.start();
-    expect(server.url).to.equal("ws://0.0.0.0:8090");
+    expect(server.url).to.oneOf([
+      "ws://localhost:8090",
+      "ws://[::1]:8090"
+    ]);
   });
 
   it("connects", async () => {

--- a/packages/server/src/Server.ts
+++ b/packages/server/src/Server.ts
@@ -71,7 +71,7 @@ export interface ServerConfig {
 export class Server extends ServerEventEmitter {
   public static DEFAULT_CONFIG: ServerConfig = {
     autoStart: false,
-    host: "0.0.0.0",
+    host: "localhost",
     id: "default",
     port: 8090,
     autoRun: false,
@@ -272,8 +272,12 @@ export class Server extends ServerEventEmitter {
 
   public get url(): string {
     if (this.wss) {
-      const { address, port } = this.wss.address() as WebSocket.AddressInfo;
-      return `ws://${address}:${port}`;
+      const { address, port, family } = this.wss.address() as WebSocket.AddressInfo;
+      if (family === "IPv6") {
+        return `ws://[${address}]:${port}`;
+      } else {
+        return `ws://${address}:${port}`;
+      }
     } else {
       throw new Error("Cannot get url of a server that is not listening");
     }
@@ -339,7 +343,7 @@ export class Server extends ServerEventEmitter {
       if (typeof msg.action !== "string") {
         throw new Error("Expected message to have an action property");
       }
-      
+
       this.debug(`Received a '${msg.action}' message: %o`, msg);
       if (msg.action === "event") {
         if (this.runner) {


### PR DESCRIPTION
## Breaking 💥 

This PR updates the default hostname to point to `localhost` instead of the `0.0.0.0` loop back IPv4 address, which might break some situations.

The tests depends on defaults for the server and client to connect to listen on an connect to same host.
As the `Server` had a default on an IPv4 address (`0.0.0.0`) the tests failed on a machine with IPv6 enabled by default.