### PR TITLE
First stab at a Node.js CLI wrapping the Mocha Remote client

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
       ],
       "devDependencies": {
         "@nx/js": "^19.3.2",
+        "@tsconfig/node16": "^16.1.3",
         "@types/chai": "^4",
         "@types/debug": "^4.1.12",
         "@types/mocha": "^10.0.10",
@@ -6620,10 +6621,11 @@
       "dev": true
     },
     "node_modules/@tsconfig/node16": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
-      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
-      "dev": true
+      "version": "16.1.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-16.1.3.tgz",
+      "integrity": "sha512-9nTOUBn+EMKO6rtSZJk+DcqsfgtlERGT9XPJ5PRj/HNENPCBY1yu/JEj5wT6GLtbCLBO2k46SeXDaY0pjMqypw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/chai": {
       "version": "4.3.14",
@@ -8124,7 +8126,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
       "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
-      "dev": true,
       "dependencies": {
         "balanced-match": "^1.0.0"
       }
@@ -13739,6 +13740,10 @@
       "resolved": "packages/mocha",
       "link": true
     },
+    "node_modules/mocha-remote-node": {
+      "resolved": "packages/node",
+      "link": true
+    },
     "node_modules/mocha-remote-react-native": {
       "resolved": "packages/react-native",
       "link": true
@@ -16897,6 +16902,13 @@
         }
       }
     },
+    "node_modules/ts-node/node_modules/@tsconfig/node16": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/ts-node/node_modules/diff": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
@@ -18117,6 +18129,69 @@
       "dependencies": {
         "base64-js": "^1.3.1",
         "ieee754": "^1.2.1"
+      }
+    },
+    "packages/mochawesome-test": {
+      "name": "mocha-remote-mochawesome-test",
+      "extraneous": true,
+      "dependencies": {
+        "mocha-remote-cli": "1.12.3",
+        "mocha-remote-node": "1.12.3",
+        "mochawesome": "^7.1.3"
+      }
+    },
+    "packages/node": {
+      "name": "mocha-remote-node",
+      "version": "1.12.3",
+      "dependencies": {
+        "glob": "^10.4.5"
+      },
+      "bin": {
+        "mocha-remote-node": "mocha-remote-node.js"
+      }
+    },
+    "packages/node/node_modules/glob": {
+      "version": "10.4.5",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
+      "integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "packages/node/node_modules/minimatch": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "packages/node/node_modules/minipass": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
+      "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
       }
     },
     "packages/react-native": {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   "bugs": "https://github.com/kraenhansen/mocha-remote/issues",
   "license": "ISC",
   "devDependencies": {
+    "@tsconfig/node16": "^16.1.3",
     "@types/chai": "^4",
     "@types/debug": "^4.1.12",
     "@types/mocha": "^10.0.10",

--- a/packages/client/src/serialization.ts
+++ b/packages/client/src/serialization.ts
@@ -24,6 +24,13 @@ function toJSON(value: Record<string, unknown>): Record<string, unknown> {
       Object.assign(result, {
         "type": "suite",
         "$$total": value.total(),
+        // TODO: Implement a DeserializedSuite on the client side to properly reconstruct it
+        "suites": [],
+        "tests": [],
+        "_beforeAll": [],
+        "_beforeEach": [],
+        "_afterAll": [],
+        "_afterEach": [],
       });
     }
     return result;

--- a/packages/node/mocha-remote-node.js
+++ b/packages/node/mocha-remote-node.js
@@ -1,0 +1,2 @@
+#!/usr/bin/env node
+import "./dist/cli.js"

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "mocha-remote-node",
+  "version": "1.12.3",
+  "type": "module",
+  "description": "Node.js wrapper for the Mocha Remote Client",
+  "bin": "./mocha-remote-node.js",
+  "scripts": {
+    "start": "tsx src/cli.ts",
+    "build": "tsc"
+  },
+  "dependencies": {
+    "glob": "^10.4.5"
+  }
+}

--- a/packages/node/src/cli.ts
+++ b/packages/node/src/cli.ts
@@ -1,0 +1,70 @@
+import os from "node:os";
+import { globSync } from "glob";
+import { Client } from "mocha-remote-client";
+
+/* eslint-disable no-console */
+
+// TODO: Add support for existing Mocha runtime options for "file handling"
+
+/*
+ * File Handling
+ *       --extension          File extension(s) to load
+ *                                            [array] [default: ["js","cjs","mjs"]]
+ *       --file               Specify file(s) to be loaded prior to root suite
+ *                            execution                   [array] [default: (none)]
+ *       --ignore, --exclude  Ignore file(s) or glob pattern(s)
+ *                                                        [array] [default: (none)]
+ *       --recursive          Look for tests in subdirectories            [boolean]
+ *   -r, --require            Require module              [array] [default: (none)]
+ *   -S, --sort               Sort test files                             [boolean]
+ *   -w, --watch              Watch files in the current working directory for
+ *                            changes                                     [boolean]
+ *       --watch-files        List of paths or globs to watch               [array]
+ *       --watch-ignore       List of paths or globs to exclude from watching
+ *                                       [array] [default: ["node_modules",".git"]]
+ */
+
+interface ConnectionRefusedError extends AggregateError {
+  errors: { code: "ECONNREFUSED", address: string, port: number }[];
+}
+
+function isConnectionRefusedError(error: unknown): error is ConnectionRefusedError {
+  return error instanceof AggregateError && error.errors.every((error: unknown) => {
+    return error instanceof Error &&
+      "code" in error && error.code === "ECONNREFUSED" &&
+      "port" in error && typeof error.port === "number";
+  });
+}
+
+const client = new Client({
+  title: `Node.js v${process.versions.node} on ${os.platform()}`,
+  autoConnect: false,
+  autoReconnect: false,
+  async tests(context) {
+    Object.assign(global, {
+      environment: { ...context, node: true },
+    });
+    // TODO: Is there a more reliable way to get the interpreter and command skipped?
+    const [, , patterns] = process.argv;
+    const testPaths = globSync(patterns, { absolute: true });
+    for (const testPath of testPaths) {
+      await import(testPath);
+    }
+  },
+});
+
+try {
+  await client.connect();
+} catch (error) {
+  process.exitCode = 1;
+  if (isConnectionRefusedError(error)) {
+    const attempts = error.errors.map(error => `${error.address}:${error.port}`);
+    const command = "npx mocha-remote -- mocha-remote-node src/*.test.ts";
+    const suggestion = "Are you wrapping the mocha-remote-node CLI with the mocha-remote?";
+    console.error(`Connection refused (tried ${attempts.join(" / ")}).\n${suggestion}\n${command}`);
+  } else if (error instanceof Error) {
+    console.error("Mocha Remote Client failed:", error.stack);
+  } else {
+    console.error("Mocha Remote Client failed:", error);
+  }
+ }

--- a/packages/node/tsconfig.json
+++ b/packages/node/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": ["@tsconfig/node16"],
+  "compilerOptions": {
+    "outDir": "dist",
+    "target": "es2022",
+    "lib": ["es2022"]
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
Heavily inspired by https://github.com/realm/realm-js/blob/main/integration-tests/environments/node/index.mjs

This also brings a change to the client, improving the transformation of WebSocket error events into errors.